### PR TITLE
Feat/websocket actor handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
     libraryDependencies += scalaTest % Test
   )
 
-val AkkaVersion = "2.6.8"
+val AkkaVersion = "2.6.14"
 val AkkaHttpVersion = "10.2.4"
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.1",

--- a/src/main/scala/client/DiscordMessageConsumerActor.scala
+++ b/src/main/scala/client/DiscordMessageConsumerActor.scala
@@ -1,0 +1,66 @@
+package client
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, Behavior}
+import client.websocket.{HelloEventData, IdentityEventData, IdentityProperties, IncomingDiscordMessage, OutgoingDiscordMessage, ReadyEventData, outgoingDiscordMessageFormat}
+
+object DiscordMessageConsumerActor {
+  type SendMessageFn = (OutgoingDiscordMessage) => Unit;
+
+  // TODO: temporary, I believe we should inject the config when constructing the actor system instead
+  final case class ReceiveMessage(m: IncomingDiscordMessage, config: DiscordWebsocketClientConfig)
+
+  def createOutgoingPayloadHeartbeat(lastSeenSequenceNumber: Option[Int]) =
+    OutgoingDiscordMessage(op = 1) // TODO: Pass lastSeenSequenceNumber
+
+  def createIdentityPayload(config: DiscordWebsocketClientConfig) = OutgoingDiscordMessage(
+    op = 2,
+    d = Right(
+      Some(
+        IdentityEventData(
+          token = config.token,
+          intents = 32767,
+          properties = IdentityProperties(
+            $os = "Windows",
+            $browser = "disco",
+            $device = "disco"
+          ),
+          shard = Some((0, 1)),
+          compress = Some(false),
+          large_threshold = Some(250)
+        )
+      )
+    )
+  )
+
+  def onDiscordMessage(
+    sendMessage: SendMessageFn
+  )(message: IncomingDiscordMessage, config: DiscordWebsocketClientConfig) = {
+    message.d.map { (optionalData) =>
+      optionalData.map {
+        case ReadyEventData(v, user, guilds, session_id, shard) => {
+          println("##############################################")
+          println("I'm ready!")
+          println("##############################################")
+        }
+        case HelloEventData(heartbeat_interval) => {
+          sendMessage(createOutgoingPayloadHeartbeat(None));
+
+          sendMessage(createIdentityPayload(config))
+        }
+      }
+    }
+  }
+
+  def apply(queue: ActorRef[EnqueueOutgoingMessage]): Behavior[ReceiveMessage] = Behaviors.receive { (context, message) =>
+    context.log.info("Hello {}!", message)
+
+    val sendMessageFn: SendMessageFn = (outgoing: OutgoingDiscordMessage) => {
+      val jsonString = outgoingDiscordMessageFormat.write(outgoing).toString();
+      queue ! EnqueueOutgoingMessage(jsonString)
+    }
+    onDiscordMessage(sendMessageFn)(message.m, message.config)
+
+    Behaviors.same
+  }
+}

--- a/src/main/scala/client/DiscordMessageQueueActor.scala
+++ b/src/main/scala/client/DiscordMessageQueueActor.scala
@@ -12,7 +12,7 @@ object DiscordMessageQueueActor {
   def apply(queue: SourceQueue[Message]): Behavior[EnqueueOutgoingMessage] = {
     Behaviors.receive { (context, message) =>
       context.log.info("Got {}", message);
-      // TODO: This will probably error if called from multiple threads :(
+      // TODO: Handle errors
       queue.offer(TextMessage(message.text));
 
       Behaviors.same

--- a/src/main/scala/client/DiscordMessageQueueActor.scala
+++ b/src/main/scala/client/DiscordMessageQueueActor.scala
@@ -9,7 +9,7 @@ import akka.stream.scaladsl.SourceQueue
 final case class EnqueueOutgoingMessage(text: String)
 
 object DiscordMessageQueueActor {
-  def create(queue: SourceQueue[Message]): Behavior[EnqueueOutgoingMessage] = {
+  def apply(queue: SourceQueue[Message]): Behavior[EnqueueOutgoingMessage] = {
     Behaviors.receive { (context, message) =>
       context.log.info("Got {}", message);
       // TODO: This will probably error if called from multiple threads :(

--- a/src/main/scala/client/DiscordMessageQueueActor.scala
+++ b/src/main/scala/client/DiscordMessageQueueActor.scala
@@ -1,0 +1,21 @@
+package client
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.Behavior
+import akka.http.scaladsl.model.ws.TextMessage
+import akka.http.scaladsl.model.ws.Message
+import akka.stream.scaladsl.SourceQueue
+
+final case class EnqueueOutgoingMessage(text: String)
+
+object DiscordMessageQueueActor {
+  def create(queue: SourceQueue[Message]): Behavior[EnqueueOutgoingMessage] = {
+    Behaviors.receive { (context, message) =>
+      context.log.info("Got {}", message);
+      // TODO: This will probably error if called from multiple threads :(
+      queue.offer(TextMessage(message.text));
+
+      Behaviors.same
+    }
+  }
+}

--- a/src/main/scala/client/DiscordWebsocketClient.scala
+++ b/src/main/scala/client/DiscordWebsocketClient.scala
@@ -1,8 +1,8 @@
 package client
 
 import akka.NotUsed
-import akka.actor.typed.{ActorRef, Behavior, Terminated}
-import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy, Terminated}
+import akka.actor.typed.scaladsl.{Behaviors, Routers}
 import akka.http.scaladsl.model.ws.TextMessage
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -14,7 +14,12 @@ import client.websocket.{IncomingDiscordMessage, OutgoingDiscordMessage}
 
 case class DiscordWebsocketClientConfig(
   gatewayUrl: String = "wss://gateway.discord.gg/?v=9&encoding=json",
-  token: String
+  token: String,
+  scaling: DiscordWebsocketClientScalingConfig = DiscordWebsocketClientScalingConfig()
+)
+
+case class DiscordWebsocketClientScalingConfig(
+    consumerInstances: Int = 4
 )
 
 class DiscordWebsocketClient(config: DiscordWebsocketClientConfig) {
@@ -26,14 +31,13 @@ class DiscordWebsocketClient(config: DiscordWebsocketClientConfig) {
 
   var messageConsumerActor: ActorRef[DiscordMessageConsumerActor.ReceiveMessage] = _;
 
-  val messageSinkFactory: WebsocketMessageSinkFactory = (queue) => Sink.foreach {
-    case message: TextMessage.Strict => {
+  val messageSinkFactory: WebsocketMessageSinkFactory = (_) => Sink.foreach {
+    case message: TextMessage.Strict =>
       Debug.log("Received raw:", message);
       val parsed = Unmarshal(message.text).to[IncomingDiscordMessage];
       Debug.log("Received parsed:", parsed);
 
       parsed.map(p => messageConsumerActor ! ReceiveMessage(p))
-    }
   };
 
   val websocketClient = new WebsocketClient(WebsocketClientConfig(
@@ -50,11 +54,19 @@ class DiscordWebsocketClient(config: DiscordWebsocketClientConfig) {
   }
 
   def createActors(): Behavior[NotUsed] =
-    Behaviors.setup { context =>
-      val messageQueueActor = context.spawn(DiscordMessageQueueActor(this.websocketClient.queue), "messageQueueActor")
-      val messageConsumerActor = context.spawn(DiscordMessageConsumerActor(messageQueueActor, config), "messageConsumerActor")
-      this.messageConsumerActor = messageConsumerActor;
-      context.watch(messageConsumerActor)
+    Behaviors.setup { ctx =>
+      val messageQueueActor = ctx.spawn(DiscordMessageQueueActor(this.websocketClient.queue), "messageQueueActor")
+
+      val messageConsumerActorPool = Routers.pool(poolSize = config.scaling.consumerInstances) {
+        // make sure the workers are restarted if they fail
+        val actor = DiscordMessageConsumerActor(messageQueueActor, config)
+        Behaviors.supervise(actor).onFailure[Exception](SupervisorStrategy.restart)
+      }
+      val messageConsumerRouter = ctx.spawn(messageConsumerActorPool, "messageConsumerActorPool")
+
+      this.messageConsumerActor = messageConsumerRouter;
+
+      ctx.watch(messageConsumerActor)
 
       Behaviors.receiveSignal {
         case (_, Terminated(_)) =>

--- a/src/main/scala/client/DiscordWebsocketClient.scala
+++ b/src/main/scala/client/DiscordWebsocketClient.scala
@@ -62,15 +62,3 @@ class DiscordWebsocketClient(config: DiscordWebsocketClientConfig) {
       }
     }
 }
-
-object Printer {
-
-  case class PrintMe(message: String)
-
-  def apply(): Behavior[PrintMe] =
-    Behaviors.receive {
-      case (context, PrintMe(message)) =>
-        context.log.info(message)
-        Behaviors.same
-    }
-}

--- a/src/main/scala/client/WebsocketClient.scala
+++ b/src/main/scala/client/WebsocketClient.scala
@@ -30,16 +30,16 @@ object WebsocketClientTypes {
 
 class WebsocketClient(config: WebsocketClientConfig) {
   implicit val system: ActorSystem = ActorSystem("websocket")
-  import system.dispatcher
+  import system.dispatcher;
+
+  val (queue, source) = Source
+    .queue[Message](
+      WebsocketQueueConfig.bufferSize,
+      WebsocketQueueConfig.overflowStrategy
+    )
+    .preMaterialize();
 
   def run(): Unit = {
-    val (queue, source) = Source
-      .queue[Message](
-        WebsocketQueueConfig.bufferSize,
-        WebsocketQueueConfig.overflowStrategy
-      )
-      .preMaterialize();
-
     val sink: WebsocketClientTypes.WebsocketMessageSink = config.messageSinkFactory(queue);
     val flow = Flow.fromSinkAndSourceMat(sink, source)(Keep.both)
 

--- a/src/main/scala/client/WebsocketClient.scala
+++ b/src/main/scala/client/WebsocketClient.scala
@@ -20,7 +20,8 @@ case class WebsocketClientConfig(
 
 object WebsocketQueueConfig {
   val bufferSize = 1000
-  val overflowStrategy = OverflowStrategy.backpressure
+  val overflowStrategy: OverflowStrategy = OverflowStrategy.backpressure
+  val maxConcurrency = 16
 }
 
 object WebsocketClientTypes {
@@ -35,7 +36,8 @@ class WebsocketClient(config: WebsocketClientConfig) {
   val (queue, source) = Source
     .queue[Message](
       WebsocketQueueConfig.bufferSize,
-      WebsocketQueueConfig.overflowStrategy
+      WebsocketQueueConfig.overflowStrategy,
+      WebsocketQueueConfig.maxConcurrency
     )
     .preMaterialize();
 

--- a/src/main/scala/client/websocket/OutgoingEventData.scala
+++ b/src/main/scala/client/websocket/OutgoingEventData.scala
@@ -36,25 +36,7 @@ object OutgoingEventDataFormat {
 
   implicit val outgoingEventDataFormat = new JsonFormat[OutgoingEventData] {
     override def write(obj: OutgoingEventData): JsValue = obj match {
-      case IdentityEventData(
-            _,
-            token,
-            intents,
-            properties,
-            compress,
-            large_threshold,
-            shard,
-            presence
-          ) =>
-        JsObject(
-          "token" -> token.toJson,
-          "intents" -> intents.toJson,
-          "properties" -> properties.toJson,
-          "compress" -> compress.toJson,
-          "large_threshold" -> large_threshold.toJson,
-          "shard" -> shard.toJson,
-          "presence" -> presence.toJson
-        )
+      case obj: IdentityEventData => obj.toJson
     }
 
     override def read(json: JsValue): OutgoingEventData = {


### PR DESCRIPTION
Todo:
- [ ] Reimplement heartbeat - we probably need a supervisor, once we get a Hello, the DiscordMessageConsumerActor will tell supervisor to start heartbeating
https://stackoverflow.com/questions/23802848/how-to-periodically-execute-an-akka-actors-routine
- [ ] Deal with the process crashing when multiple actor instances try to write to queue
- [ ] Make Actor interaction more reliable (drop fire&forget in favor of #5) (maybe without heartbeat for now)